### PR TITLE
Redirect `admiral-domains.txt` to `getadmiral-domains.txt`

### DIFF
--- a/filters/admiral-domains.txt
+++ b/filters/admiral-domains.txt
@@ -1,1 +1,13 @@
-getadmiral-domains.txt
+[Adblock Plus 2.0]
+! Redirect: https://raw.githubusercontent.com/LanikSJ/ubo-filters/master/filters/getadmiral-domains.txt
+! Title: GetAdmiral Domains Filter List
+! Homepage: https://laniksj.github.io/ubo-filters
+! License: https://www.gnu.org/licenses/gpl-3.0.en.html
+!
+! Description: A list of blocked GetAdmiral Domains.
+!
+! Legal Disclaimer (Terms and Conditions):
+! In no event shall this list, or the list author be liable for any indirect, direct, punitive,
+! special, incidental, or consequential damages whatsoever. By downloading or viewing, or using
+! this list, you are accepting these terms and the license.
+!


### PR DESCRIPTION
> ! Redirect: `http://example.com/list.txt`

> This comment indicates that the filter list has moved to a new download address. Adblock Plus will ignore any file contents beyond that comment and immediately try downloading from the new address. In case of success the address of the filter list will be updated in the settings. This comment is ignored if the new address is the same as the current address, meaning that it can be used to enforce the "canonical" address of the filter list. 

> source: https://adblockplus.org/filters#special-comments