### PR TITLE
Disable Malware Domains Update GitHub Action

### DIFF
--- a/.github/workflows/malware-domains.yml
+++ b/.github/workflows/malware-domains.yml
@@ -1,8 +1,8 @@
 name: malware-domains-list
 
 on:
-  schedule:
-    - cron: '30 1 * * 1'
+  # schedule:
+  #   - cron: '30 1 * * 1'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
- Disable Update of Malware Domains List Until a Replacement is Found