### PR TITLE
Disable Download of Malware Domains from Dead S3 Bucket

### DIFF
--- a/scripts/malware-domains.sh
+++ b/scripts/malware-domains.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 cd filters || exit
-../scripts/remove-lines.sh malware-domains.txt 15 >malware-domains-temp.txt && mv malware-domains-temp.txt malware-domains.txt
-curl -L http://malwarepatrolexport-covid-19.s3-website.us-east-2.amazonaws.com/domains/domains.txt | sed -e 's/^/||/' -e 's/$/^/' | sort -d >>malware-domains.txt
+# ../scripts/remove-lines.sh malware-domains.txt 15 >malware-domains-temp.txt && mv malware-domains-temp.txt malware-domains.txt
+# AWS S3 bucket no longere exists
+# curl -L http://malwarepatrolexport-covid-19.s3-website.us-east-2.amazonaws.com/domains/domains.txt | sed -e 's/^/||/' -e 's/$/^/' | sort -d >>malware-domains.txt
 perl ../scripts/addChecksum.pl malware-domains.txt
 perl ../scripts/sorter.pl malware-domains.txt


### PR DESCRIPTION
- `http://malwarepatrolexport-covid-19.s3-website.us-east-2.amazonaws.com/domains/domains.txt` is dead 
- Disable CURL of that URL