### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/combined-filters.yml
+++ b/.github/workflows/combined-filters.yml
@@ -1,5 +1,9 @@
 name: Combined Filters
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   # schedule:
   #   - cron: '0 3 * * 1'


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/ubo-filters/security/code-scanning/1](https://github.com/LanikSJ/ubo-filters/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file to define the least privileges required. Based on the workflow's functionality, it needs `contents: read` to access repository contents and `pull-requests: write` to create and manage pull requests. These permissions should be sufficient for the workflow to function correctly while minimizing unnecessary access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
