### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/admiral-domains.yml
+++ b/.github/workflows/admiral-domains.yml
@@ -5,6 +5,10 @@ on:
    - cron: '30 0 * * 1' # Runs 00:30 UTC Only on Monday
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   Updates:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/ubo-filters/security/code-scanning/2](https://github.com/LanikSJ/ubo-filters/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the actions used in the workflow, the following permissions are necessary:
- `contents: read` for reading repository contents.
- `pull-requests: write` for creating and automating pull requests.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the `Updates` job to limit permissions to that specific job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
