### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,5 +1,9 @@
 name: Auto Approve
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   pull_request_target:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/ubo-filters/security/code-scanning/3](https://github.com/LanikSJ/ubo-filters/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow interacts with pull requests, it likely requires `pull-requests: write` permission. Additionally, it may need `contents: read` to access repository contents.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`auto-approve`) to limit its scope. In this case, adding it at the root level is sufficient and ensures clarity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
