### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/fanboy-social.yml
+++ b/.github/workflows/fanboy-social.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 2 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   Updates:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/ubo-filters/security/code-scanning/4](https://github.com/LanikSJ/ubo-filters/security/code-scanning/4)

To fix the issue, add a `permissions` block at the root of the workflow to define the least privileges required. Based on the workflow's functionality, it needs `contents: read` for accessing repository contents and `pull-requests: write` for creating and managing pull requests. This ensures the `GITHUB_TOKEN` has only the necessary permissions.

The `permissions` block should be added at the root level, applying to all jobs in the workflow. This avoids redundancy and ensures consistent permissions across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
