### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dead-domains-check.yml
+++ b/.github/workflows/dead-domains-check.yml
@@ -14,6 +14,10 @@ on:
       - '.github/workflows/dead-domains-check.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   dead-domains-check:
     name: Run Dead Domains


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/ubo-filters/security/code-scanning/5](https://github.com/LanikSJ/ubo-filters/security/code-scanning/5)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow performs actions like reading repository contents, creating branches, pushing commits, and creating pull requests, we will grant `contents: read` and `pull-requests: write` permissions. These permissions are sufficient for the tasks performed by the workflow while adhering to the principle of least privilege.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`dead-domains-check`) to limit its scope.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
