### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/malware-domains.yml
+++ b/.github/workflows/malware-domains.yml
@@ -5,6 +5,10 @@ on:
   #   - cron: '30 1 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   Updates:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/ubo-filters/security/code-scanning/6](https://github.com/LanikSJ/ubo-filters/security/code-scanning/6)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow:
- `contents: read` is required for reading repository contents.
- `pull-requests: write` is required for creating and automating pull requests.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `Updates` job. Adding it at the root level is more concise and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
