### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node-update-deps.yml
+++ b/.github/workflows/node-update-deps.yml
@@ -1,4 +1,8 @@
 name: NodeJS Dependencies Update
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
 
 env:
   NODE_VERSION: 20


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/ubo-filters/security/code-scanning/7](https://github.com/LanikSJ/ubo-filters/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Specifically:
- `contents: read` is needed to read the repository contents.
- `pull-requests: write` is required to create pull requests.
- `issues: write` is required to add labels to pull requests.

The `permissions` block will be added after the `name` field at the top of the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
