### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-license.yml
+++ b/.github/workflows/update-license.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 10 1 1 *' # 10:00 AM on January 1
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   action-update-license-year:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/ubo-filters/security/code-scanning/9](https://github.com/LanikSJ/ubo-filters/security/code-scanning/9)

To fix the issue, add a `permissions` block at the root of the workflow file to define the minimal permissions required. Based on the workflow's functionality:
- The `contents: write` permission is needed for the `FantasticFiasco/action-update-license-year` action to update the license file and create a pull request.
- The `pull-requests: write` permission is needed for the `gh pr merge` command to merge the pull request.

The `permissions` block will be added at the root level to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
