### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -1,5 +1,9 @@
 name: Restyled
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   pull_request:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/ubo-filters/security/code-scanning/10](https://github.com/LanikSJ/ubo-filters/security/code-scanning/10)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, the following permissions are necessary:
- `contents: read` for accessing repository contents.
- `pull-requests: write` for creating and managing pull requests.

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs unless overridden by a job-specific `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
