### PR TITLE
chore(deps): update actions/deploy-pages action to v4.0.5

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -6,7 +6,7 @@ on:
     paths:
       - README.md
       - _config.yml
-      - '!**/.vscode/**'
+      - "!**/.vscode/**"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -49,4 +49,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.0
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
- Update the GitHub Pages deployment action to the latest patch version (v4.0.5) to ensure compatibility and access to the latest bug fixes and improvements.