### PR TITLE
chore(ci): replace brew install with direct fop binary download

### DIFF
--- a/.github/workflows/admiral-domains.yml
+++ b/.github/workflows/admiral-domains.yml
@@ -21,7 +21,13 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install FOP CLI
-        run: HOMEBREW_NO_AUTO_UPDATE=1 brew install laniksj/tap/fop-rs
+        run: |
+          mkdir -p ~/.local/bin
+          LATEST_TAG=$(curl -sL -o /dev/null -w "%{url_effective}" https://github.com/ryanbr/fop-rs/releases/latest | awk -F/ '{print $NF}')
+          VERSION=${LATEST_TAG#v}
+          curl -sSL --connect-timeout 20 --retry 5 --retry-delay 2 "https://github.com/ryanbr/fop-rs/releases/download/${LATEST_TAG}/fop-${VERSION}-linux-x86_64" -o ~/.local/bin/fop
+          chmod +x ~/.local/bin/fop
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Download Admiral List
         run: |

--- a/.github/workflows/combined-filters.yml
+++ b/.github/workflows/combined-filters.yml
@@ -16,7 +16,13 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install FOP CLI
-        run: HOMEBREW_NO_AUTO_UPDATE=1 brew install laniksj/tap/fop-rs
+        run: |
+          mkdir -p ~/.local/bin
+          LATEST_TAG=$(curl -sL -o /dev/null -w "%{url_effective}" https://github.com/ryanbr/fop-rs/releases/latest | awk -F/ '{print $NF}')
+          VERSION=${LATEST_TAG#v}
+          curl -sSL --connect-timeout 20 --retry 5 --retry-delay 2 "https://github.com/ryanbr/fop-rs/releases/download/${LATEST_TAG}/fop-${VERSION}-linux-x86_64" -o ~/.local/bin/fop
+          chmod +x ~/.local/bin/fop
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Update Combined Filters
         run: |

--- a/.github/workflows/dead-domains-check.yml
+++ b/.github/workflows/dead-domains-check.yml
@@ -33,7 +33,13 @@ jobs:
           cache: npm
 
       - name: Install FOP CLI
-        run: HOMEBREW_NO_AUTO_UPDATE=1 brew install laniksj/tap/fop-rs
+        run: |
+          mkdir -p ~/.local/bin
+          LATEST_TAG=$(curl -sL -o /dev/null -w "%{url_effective}" https://github.com/ryanbr/fop-rs/releases/latest | awk -F/ '{print $NF}')
+          VERSION=${LATEST_TAG#v}
+          curl -sSL --connect-timeout 20 --retry 5 --retry-delay 2 "https://github.com/ryanbr/fop-rs/releases/download/${LATEST_TAG}/fop-${VERSION}-linux-x86_64" -o ~/.local/bin/fop
+          chmod +x ~/.local/bin/fop
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Install Dependencies
         run: npm install

--- a/.github/workflows/fanboy-social.yml
+++ b/.github/workflows/fanboy-social.yml
@@ -21,7 +21,13 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install FOP CLI
-        run: HOMEBREW_NO_AUTO_UPDATE=1 brew install laniksj/tap/fop-rs
+        run: |
+          mkdir -p ~/.local/bin
+          LATEST_TAG=$(curl -sL -o /dev/null -w "%{url_effective}" https://github.com/ryanbr/fop-rs/releases/latest | awk -F/ '{print $NF}')
+          VERSION=${LATEST_TAG#v}
+          curl -sSL --connect-timeout 20 --retry 5 --retry-delay 2 "https://github.com/ryanbr/fop-rs/releases/download/${LATEST_TAG}/fop-${VERSION}-linux-x86_64" -o ~/.local/bin/fop
+          chmod +x ~/.local/bin/fop
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Download Fanboy Social
         run: |

--- a/.github/workflows/malware-domains.yml
+++ b/.github/workflows/malware-domains.yml
@@ -13,7 +13,13 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
       - name: Install FOP CLI
-        run: HOMEBREW_NO_AUTO_UPDATE=1 brew install laniksj/tap/fop-rs
+        run: |
+          mkdir -p ~/.local/bin
+          LATEST_TAG=$(curl -sL -o /dev/null -w "%{url_effective}" https://github.com/ryanbr/fop-rs/releases/latest | awk -F/ '{print $NF}')
+          VERSION=${LATEST_TAG#v}
+          curl -sSL --connect-timeout 20 --retry 5 --retry-delay 2 "https://github.com/ryanbr/fop-rs/releases/download/${LATEST_TAG}/fop-${VERSION}-linux-x86_64" -o ~/.local/bin/fop
+          chmod +x ~/.local/bin/fop
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
       - name: Download Malware Domains List
         run: "./scripts/checksum-sort.sh filters/malware-domains.txt
 


### PR DESCRIPTION
- remove linuxbrew since it's not likely to be installed
- use direction download with version checking
