### PR TITLE
chore: delete restyled configuration file

### DIFF
--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -1,7 +1,0 @@
----
-# Restyled configuration
-# https://github.com/restyled-io/restyled.io/wiki/Configuring-Restyled
-
-# Files to ignore
-exclude:
-  - "scripts/FOP.py"


### PR DESCRIPTION
- remove the file since `FOP.py` no longer exists
