### PR TITLE
chore: remove filters/*.txt trigger path from dead-domains-check workflow

### DIFF
--- a/.github/workflows/dead-domains-check.yml
+++ b/.github/workflows/dead-domains-check.yml
@@ -15,7 +15,6 @@ on:
   pull_request:
     paths:
       - ".github/workflows/dead-domains-check.yml"
-      - "filters/*.txt"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
- caused PRs to close before they got merged
