### PR TITLE
ci: update dependency update schedule to Monday 11:00 UTC

### DIFF
--- a/.github/workflows/node-update-deps.yml
+++ b/.github/workflows/node-update-deps.yml
@@ -2,11 +2,11 @@ name: NodeJS Dependencies Update
 
 on:
   schedule:
-    # Run every Monday at 11:00 UTC
-    - cron: '0 11 * * 1'
+    # Run every Monday at 10:00 UTC
+    - cron: "0 10 * * 1"
   pull_request:
     paths:
-      - '.github/workflows/node-update-deps.yml'
+      - ".github/workflows/node-update-deps.yml"
   workflow_dispatch: # Allow manual trigger
 
 permissions:
@@ -54,8 +54,8 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: 'chore(deps): update node dependencies'
-          title: 'chore(deps): update node dependencies'
+          commit-message: "chore(deps): update node dependencies"
+          title: "chore(deps): update node dependencies"
           body: |
             This is an automated pull request to update NodeJS dependencies.
           branch: feature/node-deps-update

--- a/.github/workflows/node-update-deps.yml
+++ b/.github/workflows/node-update-deps.yml
@@ -2,11 +2,11 @@ name: NodeJS Dependencies Update
 
 on:
   schedule:
-    # Run every Monday at 08:00 UTC
-    - cron: "0 8 * * 2"
+    # Run every Monday at 11:00 UTC
+    - cron: '0 11 * * 1'
   pull_request:
     paths:
-      - ".github/workflows/node-update-deps.yml"
+      - '.github/workflows/node-update-deps.yml'
   workflow_dispatch: # Allow manual trigger
 
 permissions:
@@ -54,8 +54,8 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "chore(deps): update node dependencies"
-          title: "chore(deps): update node dependencies"
+          commit-message: 'chore(deps): update node dependencies'
+          title: 'chore(deps): update node dependencies'
           body: |
             This is an automated pull request to update NodeJS dependencies.
           branch: feature/node-deps-update


### PR DESCRIPTION
- Change the cron trigger for the NodeJS dependencies update workflow from Tuesday 08:00 UTC to Monday 11:00 UTC to run earlier in the week. Also standardize YAML string quoting.
