### PR TITLE
ci: update dead-domains-linter export command to use `-i` flag

### DIFF
--- a/.github/workflows/admiral-domains.yml
+++ b/.github/workflows/admiral-domains.yml
@@ -46,7 +46,7 @@ jobs:
         run: npm install
 
       - name: Export Dead Domains
-        run: npx dead-domains-linter --export dead-domains.txt filters/getadmiral-domains.txt
+        run: npx dead-domains-linter --export dead-domains.txt -i filters/getadmiral-domains.txt
 
       - name: Remove Dead Domains from Admiral List
         run: |

--- a/.github/workflows/adshield-domains.yml
+++ b/.github/workflows/adshield-domains.yml
@@ -46,7 +46,7 @@ jobs:
         run: npm install
 
       - name: Export Dead Domains
-        run: npx dead-domains-linter --export dead-domains.txt filters/adshield-domains.txt
+        run: npx dead-domains-linter --export dead-domains.txt -i filters/adshield-domains.txt
 
       - name: Remove Dead Domains from AdShield List
         run: |

--- a/.github/workflows/fanboy-social.yml
+++ b/.github/workflows/fanboy-social.yml
@@ -43,7 +43,7 @@ jobs:
         run: npm install
 
       - name: Export Dead Domains
-        run: npx dead-domains-linter --export dead-domains.txt filters/fanboy-social-no-cosmetic.txt
+        run: npx dead-domains-linter --export dead-domains.txt -i filters/fanboy-social-no-cosmetic.txt
 
       - name: Remove Dead Domains from Fanboy Social
         run: |


### PR DESCRIPTION
- Updated the `dead-domains-linter` export command across multiple workflows to use the `-i` flag for specifying input files, replacing the deprecated `--export` parameter.
- Also fixed missing newlines at end of files in admiral-domains.yml and fanboy-social.yml.
