### PR TITLE
ci: add fallback to GitLab mirror for AdShield list

### DIFF
--- a/.github/workflows/adshield-domains.yml
+++ b/.github/workflows/adshield-domains.yml
@@ -33,8 +33,18 @@ jobs:
         run: |
           # Preserve header (first 15 lines) and append new domains
           ./scripts/remove-lines.sh filters/adshield-domains.txt 15 > filters/adshield-domains.tmp
-          curl -L https://raw.githubusercontent.com/hagezi/dns-blocklists/refs/heads/main/share/ad-shield.txt | sed 's/^/||/; s/$/^$third-party/' >> filters/adshield-domains.tmp
-          mv filters/adshield-domains.tmp filters/adshield-domains.txt
+
+          # Try GitHub primary source, fall back to GitLab mirror on failure
+          if curl -fsSL --fail https://raw.githubusercontent.com/hagezi/dns-blocklists/refs/heads/main/share/ad-shield.txt -o adshield-source.txt; then
+            echo "Downloaded AdShield list from GitHub"
+          else
+            echo "GitHub source failed, falling back to GitLab mirror..."
+            curl -fsSL --fail https://gitlab.com/hagezi/mirror/-/raw/main/dns-blocklists/share/ad-shield.txt -o adshield-source.txt
+          fi
+
+          sed 's/^/||/; s/$/^$third-party/' adshield-source.txt >> filters/adshield-domains.tmp
+          rm -f adshield-source.txt
+          mv -f filters/adshield-domains.tmp filters/adshield-domains.txt
 
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0


### PR DESCRIPTION
- The GitHub source for the AdShield domain list can fail, so we now try the GitLab mirror as a fallback to ensure the workflow completes successfully.
