### PR TITLE
feat: preserve custom adshield rules and update filter lists

### DIFF
--- a/filters/adshield-domains.txt
+++ b/filters/adshield-domains.txt
@@ -1,7 +1,7 @@
-! Version: 202608190201
+! Version: 202608211846
 ! Title: Ad Shield Filter List
-! Checksum: 0ojfZMiPlwBRDR1LyM64Vw
-! Last modified: 2026-08-19 02:01 UTC
+! Checksum: v5EsmHp528z4f4LGUlzqmA
+! Last modified: 2026-08-21 18:46 UTC
 ! Expires: 1 day (update frequency)
 ! Homepage: https://laniksj.github.io/ubo-filters
 ! License: https://opensource.org/licenses/MIT
@@ -13,6 +13,26 @@
 ! In no event shall this list, or the list author be liable for any indirect, direct, punitive,
 ! special, incidental, or consequential damages whatsoever. By downloading or viewing, or using
 ! this list, you are accepting these terms and the license.
+||*/session/obe*www.24sata.hr$document
+||*/session/obe*www.alo.rs$document
+||*/session/obe*www.blic.rs$document
+||*/session/obe*www.dalmacija.news$document
+||*/session/obe*www.dnevnik.hr$document
+||*/session/obe*www.index.hr$document
+||*/session/obe*www.jutarnji.ba$document
+||*/session/obe*www.jutarnji.hr$document
+||*/session/obe*www.klix.ba$document
+||*/session/obe*www.kurir.rs$document
+||*/session/obe*www.n1info.hr$document
+||*/session/obe*www.net.hr$document
+||*/session/obe*www.novac.hr$document
+||*/session/obe*www.politika.rs$document
+||*/session/obe*www.rs.n1info.com$document
+||*/session/obe*www.slobodnadalmacija.hr$document
+||*/session/obe*www.telegraf.rs$document
+||*/session/obe*www.tportal.hr$document
+||*/session/obe*www.vecernji.ba$document
+||*/session/obe*www.vecernji.hr$document
 ||07c225f3.online^$third-party
 ||19706903.xyz^$third-party
 ||38167473.xyz^$third-party

--- a/filters/ubo-filters.txt
+++ b/filters/ubo-filters.txt
@@ -1,7 +1,7 @@
 ! Title: Lanik's uBO Filter List
-! Checksum: GMPFzsbB9aYwQpDljZj-Bg
-! Last modified: 2026-08-10 20:59 UTC
-! Version: 202608102059
+! Checksum: lfehyAQJzpEu1nlMMZIdqA
+! Last modified: 2026-08-21 18:46 UTC
+! Version: 202608211846
 ! Expires: 1 day (update frequency)
 ! Homepage: https://laniksj.github.io/ubo-filters
 ! License: https://opensource.org/licenses/MIT
@@ -713,6 +713,8 @@ www.google.com##.k3bfZe > div
 www.google.com###rhs > block-component
 www.i-dont-care-about-cookies.eu###sidebar
 www.instacart.com##[href="https://www.instacart.com/p/pay-in-4"]
+www.linux.org##[href*="/donation/"]
+www.linux.org##[href^="https://adminapparel.com"]
 www.wyzant.com###desktop-cross-sell
 www.youtube.com##.action-panel-trigger[role="button"][data-trigger-for="action-panel-share"]
 www.youtube.com##.video-annotations

--- a/scripts/download-adshield.sh
+++ b/scripts/download-adshield.sh
@@ -27,6 +27,13 @@ GITLAB_MIRROR="https://gitlab.com/hagezi/mirror/-/raw/main/dns-blocklists/share/
 # Number of header lines to preserve from the existing filter file
 HEADER_LINES=15
 
+# Unique prefix matching custom rules that must be preserved across updates.
+# These rules are hand-added (not part of the upstream list) and must be
+# retained when the filter file is regenerated from the source. A fixed
+# string (grep -F) is used since the upstream '$third-party' rules never
+# contain this prefix.
+PRESERVE_PREFIX='||*/session/obe*'
+
 main() {
   local filter_file=""
   local script_dir
@@ -85,8 +92,15 @@ main() {
 
   echo "🚀 Downloading AdShield list for: $resolved_file"
 
-  # Preserve header (first N lines) and append new domains
+  # Extract custom rules that must be preserved across updates (e.g.
+  # ||*/session/obe*...*$document rules which are not part of the
+  # upstream list). These are re-appended after the downloaded content.
   local tmp_file="${resolved_file}.tmp"
+  local preserved_file
+  preserved_file="$(mktemp)"
+  grep -F "$PRESERVE_PREFIX" "$resolved_file" >"$preserved_file" || true
+
+  # Preserve header (first N lines) and append new domains
   "$script_dir/remove-lines.sh" "$resolved_file" "$HEADER_LINES" >"$tmp_file"
 
   # Try GitHub primary source, fall back to GitLab mirror on failure
@@ -111,8 +125,13 @@ main() {
   local sed_expr="s/^/||/; s/\$/^\$third-party/"
   sed "$sed_expr" "$source_file" >>"$tmp_file"
 
+  # Re-append the custom rules that must be preserved across updates
+  if [[ -s "$preserved_file" ]]; then
+    cat "$preserved_file" >>"$tmp_file"
+  fi
+
   # Clean up and atomically replace the original file
-  rm -f "$source_file"
+  rm -f "$source_file" "$preserved_file"
   mv -f "$tmp_file" "$resolved_file"
 
   echo "✅ Successfully updated '$resolved_file'"


### PR DESCRIPTION
- Add logic in download-adshield.sh to extract and re-append custom rules (e.g., "||*/session/obe*" prefixes) that are manually maintained and not part of the upstream list.
- Update filter lists: adshield-domains.txt adds regional blocking rules and bumps version; ubo-filters.txt adds new entries and updates version.
